### PR TITLE
[FIX] Rework de bullets

### DIFF
--- a/3D/entities/bullets/bullet_pistol.gd
+++ b/3D/entities/bullets/bullet_pistol.gd
@@ -1,9 +1,6 @@
-class_name BulletPistol extends GenericBullet
+extends GenericBullet
 
 func _ready():
-	BULLET_SPEED = PI/2.3
-	BULLET_MAX_TRAVEL_DISTANCE = PI/2.5
-	BULLET_DAMAGE = 25
 	super._ready()
 
 func init(pos: Vector3, alpha: float, direction: EntityDirection, radius: float, playerCrouching: bool):
@@ -13,10 +10,10 @@ func init(pos: Vector3, alpha: float, direction: EntityDirection, radius: float,
 		pos.y += 0.5
 
 	super.init(pos, alpha, direction, radius, playerCrouching)
-		
 
 func _process(_delta):
 	super._process(_delta)
 
 func _physics_process(delta):
 	super._physics_process(delta)
+

--- a/3D/entities/bullets/bullet_pistol.tscn
+++ b/3D/entities/bullets/bullet_pistol.tscn
@@ -1,28 +1,17 @@
-[gd_scene load_steps=5 format=3 uid="uid://bpd3xqnwxvtmm"]
+[gd_scene load_steps=5 format=3 uid="uid://10h8rt50ey3t"]
 
-[ext_resource type="Script" path="res://entities/bullets/bullet_pistol.gd" id="1_fucr5"]
+[ext_resource type="PackedScene" uid="uid://cir0yjv7rw8vf" path="res://entities/bullets/generic_bullet.tscn" id="1_fa7v2"]
+[ext_resource type="Script" path="res://entities/bullets/bullet_pistol.gd" id="2_33jvk"]
 
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_7b6mx"]
-albedo_color = Color(0.0431373, 1, 1, 1)
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_r32yd"]
+albedo_color = Color(0, 1, 1, 1)
 
-[sub_resource type="CapsuleMesh" id="CapsuleMesh_6ekej"]
-material = SubResource("StandardMaterial3D_7b6mx")
+[sub_resource type="CapsuleMesh" id="CapsuleMesh_rugph"]
+material = SubResource("StandardMaterial3D_r32yd")
 
-[sub_resource type="CapsuleShape3D" id="CapsuleShape3D_sv58o"]
-
-[node name="bullet_pistol" type="CharacterBody3D"]
-collision_layer = 8
-collision_mask = 34
-script = ExtResource("1_fucr5")
-
-[node name="mesh" type="MeshInstance3D" parent="."]
-transform = Transform3D(-4.37114e-09, 0.1, -4.37114e-09, 0, -4.37114e-09, -0.1, -0.1, -4.37114e-09, 1.91069e-16, 0, 0, 0)
-mesh = SubResource("CapsuleMesh_6ekej")
-
-[node name="bullet_activation_area" type="Area3D" parent="."]
-collision_layer = 8
-collision_mask = 34
-
-[node name="activation_collision" type="CollisionShape3D" parent="bullet_activation_area"]
-transform = Transform3D(-5.24537e-09, 0.12, -5.24537e-09, 0, -5.24537e-09, -0.12, -0.12, -5.24537e-09, 2.29282e-16, 0, 0, 0)
-shape = SubResource("CapsuleShape3D_sv58o")
+[node name="bullet_pistol" instance=ExtResource("1_fa7v2")]
+script = ExtResource("2_33jvk")
+mesh = SubResource("CapsuleMesh_rugph")
+mesh_scale = 0.2
+BULLET_SPEED = 1.366
+BULLET_DAMAGE = 25

--- a/3D/entities/bullets/bullet_rifle.gd
+++ b/3D/entities/bullets/bullet_rifle.gd
@@ -1,9 +1,6 @@
-class_name BulletRifle extends GenericBullet
+extends GenericBullet
 
 func _ready():
-	BULLET_SPEED = PI/1.3
-	BULLET_MAX_TRAVEL_DISTANCE = 1.7*PI
-	BULLET_DAMAGE = 50
 	super._ready()
 
 func init(pos: Vector3, alpha: float, direction: EntityDirection, radius: float, playerCrouching: bool):

--- a/3D/entities/bullets/bullet_rifle.tscn
+++ b/3D/entities/bullets/bullet_rifle.tscn
@@ -1,28 +1,18 @@
-[gd_scene load_steps=5 format=3 uid="uid://4w2k81o16j4y"]
+[gd_scene load_steps=5 format=3 uid="uid://cdwifp7oh73an"]
 
 [ext_resource type="Script" path="res://entities/bullets/bullet_rifle.gd" id="1_86gcl"]
+[ext_resource type="PackedScene" uid="uid://cir0yjv7rw8vf" path="res://entities/bullets/generic_bullet.tscn" id="1_x2r1l"]
 
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_4g5b5"]
-albedo_color = Color(0.254902, 0.14902, 0.682353, 1)
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_4yio4"]
+albedo_color = Color(0, 0, 1, 1)
 
-[sub_resource type="CapsuleMesh" id="CapsuleMesh_lgtcw"]
-material = SubResource("StandardMaterial3D_4g5b5")
+[sub_resource type="CapsuleMesh" id="CapsuleMesh_erfvp"]
+material = SubResource("StandardMaterial3D_4yio4")
 
-[sub_resource type="CapsuleShape3D" id="CapsuleShape3D_2odrn"]
-
-[node name="bullet_rifle" type="CharacterBody3D"]
-collision_layer = 8
-collision_mask = 34
+[node name="bullet_rifle" instance=ExtResource("1_x2r1l")]
 script = ExtResource("1_86gcl")
-
-[node name="mesh" type="MeshInstance3D" parent="."]
-transform = Transform3D(-8.74228e-09, 0.2, -8.74228e-09, 0, -8.74228e-09, -0.2, -0.2, -8.74228e-09, 3.82137e-16, 0, 0, 0)
-mesh = SubResource("CapsuleMesh_lgtcw")
-
-[node name="bullet_activation_area" type="Area3D" parent="."]
-collision_layer = 8
-collision_mask = 34
-
-[node name="activation_collision" type="CollisionShape3D" parent="bullet_activation_area"]
-transform = Transform3D(-1.09278e-08, 0.25, -1.09278e-08, 0, -1.09278e-08, -0.25, -0.25, -1.09278e-08, 4.77671e-16, 0, 0, 0)
-shape = SubResource("CapsuleShape3D_2odrn")
+mesh = SubResource("CapsuleMesh_erfvp")
+mesh_scale = 0.3
+BULLET_SPEED = 2.417
+BULLET_MAX_TRAVEL_DISTANCE = 5.341
+BULLET_DAMAGE = 50

--- a/3D/entities/bullets/generic_bullet.gd
+++ b/3D/entities/bullets/generic_bullet.gd
@@ -1,16 +1,21 @@
 class_name GenericBullet extends GenericEntity
 
-var BULLET_SPEED: float = PI/1.5
-var BULLET_MAX_TRAVEL_DISTANCE: float = PI/2
+@export var mesh: Mesh = null
+@export var mesh_scale: float = 1
+
+@export var BULLET_SPEED: float = PI/1.5
+@export var BULLET_MAX_TRAVEL_DISTANCE: float = PI/2
+@export var BULLET_DAMAGE: int = 33
 
 var BULLET_INITIAL_ALPHA: float = 0
-var BULLET_DAMAGE: int = 33
 
 # -----------------------------------------------
 
 func _ready():
 	entity_has_gravity = false
 	$bullet_activation_area.connect("body_entered", bullet_body_entered)
+	$mesh.mesh = mesh
+	$mesh.scale = Vector3(mesh_scale, mesh_scale, mesh_scale)
 
 func init(pos: Vector3, alpha: float, direction: EntityDirection, radius: float, _playerCrouching: bool):
 	BULLET_INITIAL_ALPHA = alpha

--- a/3D/entities/bullets/generic_bullet.tscn
+++ b/3D/entities/bullets/generic_bullet.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=3 format=3 uid="uid://cir0yjv7rw8vf"]
+
+[ext_resource type="Script" path="res://entities/bullets/generic_bullet.gd" id="1_ttwna"]
+
+[sub_resource type="CapsuleShape3D" id="CapsuleShape3D_4jgc1"]
+
+[node name="generic_bullet" type="CharacterBody3D"]
+script = ExtResource("1_ttwna")
+
+[node name="mesh" type="MeshInstance3D" parent="."]
+transform = Transform3D(-4.37114e-08, 1, -4.37114e-08, 0, -4.37114e-08, -1, -1, -4.37114e-08, 1.91069e-15, 0, 0, 0)
+
+[node name="bullet_activation_area" type="Area3D" parent="."]
+collision_layer = 8
+collision_mask = 34
+
+[node name="activation_collision" type="CollisionShape3D" parent="bullet_activation_area"]
+transform = Transform3D(-5.24537e-09, 0.12, -5.24537e-09, 0, -5.24537e-09, -0.12, -0.12, -5.24537e-09, 2.29282e-16, 0, 0, 0)
+shape = SubResource("CapsuleShape3D_4jgc1")


### PR DESCRIPTION
ahora hay una escena generic_bullet que tiene el mesh y todo eso.
para declarar una bullet nueva se hace rclick a generic_bullet.tscn -> new inherited scene.
la escena nueva tendrá ya automáticamente todos los nodos hijos de generic_bullet. 

se puede también tocar los parámetros en el export (mesh, escala del mesh, bullet speed, max travel distance, damage).